### PR TITLE
docker.io

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,12 +20,12 @@ jobs:
       - name: Build with Maven
         run: |
           mvn clean install -Prelease
-      - name: Push to ghcr.io
+      - name: Push to docker.io
         uses: mr-smithers-excellent/docker-build-push@v6
         with:
           image: tracehub/code-review-action
           tags: ${{ github.ref_name }}, latest
           dockerfile: Dockerfile
-          registry: ghcr.io
+          registry: docker.io
           username: tracehub
           password: ${{ secrets.DOCKER_PASSWORD }}


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
The focus of this PR is to update the workflow to push Docker images to `docker.io` instead of `ghcr.io`.

### Detailed summary
- Updated workflow to push Docker images to `docker.io` instead of `ghcr.io`
- Updated the push action to use `docker.io` registry
- Updated the action configuration with the new registry information

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->