### PR TITLE
feat(#2): input github token typo

### DIFF
--- a/src/main/java/git/tracehub/codereview/action/Entry.java
+++ b/src/main/java/git/tracehub/codereview/action/Entry.java
@@ -87,7 +87,7 @@ public final class Entry {
             )
         ).readObject();
         Logger.info(Entry.class, "event received %s", event.toString());
-        final String token = System.getenv().get("INPUT_GITHUBTOKEN");
+        final String token = System.getenv().get("INPUT_GITHUB_TOKEN");
         final Repo repo = new RtGithub(token)
             .repos()
             .get(new Coordinates.Simple(name));


### PR DESCRIPTION
ref #2

<!-- start pr-codex -->

---

## PR-Codex overview
This PR updates the environment variable name from `INPUT_GITHUBTOKEN` to `INPUT_GITHUB_TOKEN` for consistency and readability.

### Detailed summary
- Updated environment variable name from `INPUT_GITHUBTOKEN` to `INPUT_GITHUB_TOKEN`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->