### PR TITLE
feat(#38): submitted

### DIFF
--- a/src/main/java/git/tracehub/codereview/action/github/WithComments.java
+++ b/src/main/java/git/tracehub/codereview/action/github/WithComments.java
@@ -61,7 +61,7 @@ public final class WithComments implements Scalar<JsonArray> {
         this.origin.value().forEach(
             review -> {
                 final JsonObjectBuilder entry = Json.createObjectBuilder()
-                    .add("body", review.asJsonObject().getString("body"))
+                    .add("submitted", review.asJsonObject().getString("body"))
                     .add(
                         "comments",
                         new Authored(

--- a/src/test/resources/it/311-with-comments.json
+++ b/src/test/resources/it/311-with-comments.json
@@ -1,6 +1,6 @@
 [
   {
-    "body": "Just one",
+    "submitted": "Just one",
     "comments": [
       "h1alexbel: Just one"
     ]

--- a/src/test/resources/it/312-with-comments.json
+++ b/src/test/resources/it/312-with-comments.json
@@ -1,14 +1,14 @@
 [
   {
-    "body": "comment",
+    "submitted": "comment",
     "comments": []
   },
   {
-    "body": "approve",
+    "submitted": "approve",
     "comments": []
   },
   {
-    "body": "r",
+    "submitted": "r",
     "comments": []
   }
 ]

--- a/src/test/resources/it/313-with-comments.json
+++ b/src/test/resources/it/313-with-comments.json
@@ -1,60 +1,60 @@
 [
   {
-    "body": "LTGM!",
+    "submitted": "LTGM!",
     "comments": []
   },
   {
-    "body": "LGTM!!",
+    "submitted": "LGTM!!",
     "comments": []
   },
   {
-    "body": "lgtm",
+    "submitted": "lgtm",
     "comments": []
   },
   {
-    "body": "approve",
+    "submitted": "approve",
     "comments": []
   },
   {
-    "body": "cool",
+    "submitted": "cool",
     "comments": []
   },
   {
-    "body": "approve",
+    "submitted": "approve",
     "comments": []
   },
   {
-    "body": "test",
+    "submitted": "test",
     "comments": []
   },
   {
-    "body": "testing",
+    "submitted": "testing",
     "comments": []
   },
   {
-    "body": "0.0.7",
+    "submitted": "0.0.7",
     "comments": []
   },
   {
-    "body": "testing",
+    "submitted": "testing",
     "comments": []
   },
   {
-    "body": "testing",
+    "submitted": "testing",
     "comments": []
   },
   {
-    "body": "test",
+    "submitted": "test",
     "comments": [
       "h1alexbel: testing"
     ]
   },
   {
-    "body": "test",
+    "submitted": "test",
     "comments": []
   },
   {
-    "body": "test",
+    "submitted": "test",
     "comments": []
   }
 ]


### PR DESCRIPTION
closes #38

<!-- start pr-codex -->

---

## PR-Codex overview
This PR updates the key field name from "body" to "submitted" in JSON files and Java code related to code reviews.

### Detailed summary
- Updated field name "body" to "submitted" in JSON files for clarity
- Refactored Java code to use "submitted" instead of "body" for consistency

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->