### PR TITLE
feat(#51):  if min == 0 then execute

### DIFF
--- a/src/main/java/git/tracehub/codereview/action/SkipIfTooSmall.java
+++ b/src/main/java/git/tracehub/codereview/action/SkipIfTooSmall.java
@@ -52,7 +52,9 @@ public final class SkipIfTooSmall implements Proc<Pull> {
     @Override
     public void exec(final Pull pull) throws Exception {
         final Integer min = this.lines.value();
-        if (min != 0) {
+        if (min == 0) {
+            this.routine.exec(pull);
+        } else {
             final int changes = new ChangesCount(pull).value();
             if (min > changes) {
                 Logger.info(
@@ -73,6 +75,5 @@ public final class SkipIfTooSmall implements Proc<Pull> {
                 this.routine.exec(pull);
             }
         }
-        this.routine.exec(pull);
     }
 }


### PR DESCRIPTION
ref #51

<!-- start pr-codex -->

---

## PR-Codex overview
This PR updates the logic in `SkipIfTooSmall.java` to execute `routine` if `min` is 0, else based on `changes`.

### Detailed summary
- Updated condition to execute `routine` if `min` is 0
- Improved handling of `min` and `changes` comparison
- Removed redundant `routine.exec(pull)` call

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->