### PR TITLE
feat(#40, #41): PullChanges, PullFiles extension

### DIFF
--- a/src/main/java/git/tracehub/codereview/action/github/PullChanges.java
+++ b/src/main/java/git/tracehub/codereview/action/github/PullChanges.java
@@ -24,34 +24,39 @@
 package git.tracehub.codereview.action.github;
 
 import com.jcabi.github.Pull;
-import git.tracehub.codereview.action.extentions.PullFiles;
-import git.tracehub.codereview.action.extentions.PullFilesExtension;
-import org.hamcrest.MatcherAssert;
-import org.hamcrest.core.IsEqual;
-import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
+import javax.json.Json;
+import javax.json.JsonArray;
+import javax.json.JsonArrayBuilder;
+import lombok.RequiredArgsConstructor;
+import org.cactoos.Scalar;
 
 /**
- * Test case for {@link ChangesCount}.
+ * Pull request changes.
  *
  * @since 0.0.0
  */
-final class ChangesCountTest {
+@RequiredArgsConstructor
+public final class PullChanges implements Scalar<JsonArray> {
 
-    @Test
-    @PullFiles("git/tracehub/codereview/action/github/files.json")
-    @ExtendWith(PullFilesExtension.class)
-    void calculatesChanges(final Pull mock) throws Exception {
-        final int changes = new ChangesCount(mock).value();
-        final int expected = 31;
-        MatcherAssert.assertThat(
-            String.format(
-                "Changes count (%s) does not match with expected %s",
-                changes,
-                expected
-            ),
-            changes,
-            new IsEqual<>(expected)
+    /**
+     * Pull request.
+     */
+    private final Pull pull;
+
+    @Override
+    public JsonArray value() throws Exception {
+        final JsonArrayBuilder builder = Json.createArrayBuilder();
+        this.pull.files().forEach(
+            file -> builder.add(
+                Json.createObjectBuilder()
+                    .add("filename", file.getString("filename"))
+                    .add("additions", file.getInt("additions"))
+                    .add("deletions", file.getInt("deletions"))
+                    .add("changes", file.getInt("changes"))
+                    .add("patch", file.getString("patch"))
+                    .build()
+            )
         );
+        return builder.build();
     }
 }

--- a/src/test/java/git/tracehub/codereview/action/SkipIfTooSmallTest.java
+++ b/src/test/java/git/tracehub/codereview/action/SkipIfTooSmallTest.java
@@ -25,21 +25,16 @@ package git.tracehub.codereview.action;
 
 import com.jcabi.github.Pull;
 import com.jcabi.github.mock.MkGithub;
-import java.io.InputStreamReader;
+import git.tracehub.codereview.action.extentions.PullFiles;
+import git.tracehub.codereview.action.extentions.PullFilesExtension;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicInteger;
-import javax.json.Json;
-import javax.json.JsonObject;
 import nl.altindag.log.LogCaptor;
-import org.cactoos.io.ResourceOf;
 import org.cactoos.list.ListOf;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.core.IsEqual;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.Mock;
-import org.mockito.Mockito;
-import org.mockito.junit.jupiter.MockitoExtension;
 
 /**
  * Test case for {@link SkipIfTooSmall}.
@@ -70,17 +65,9 @@ final class SkipIfTooSmallTest {
     }
 
     @Test
-    @ExtendWith(MockitoExtension.class)
-    void skipsSmallPullRequests(@Mock final Pull mock) throws Exception {
-        final List<JsonObject> files = new ListOf<>();
-        Json.createReader(
-            new InputStreamReader(
-                new ResourceOf(
-                    "git/tracehub/codereview/action/github/small.json"
-                ).stream()
-            )
-        ).readArray().forEach(value -> files.add(value.asJsonObject()));
-        Mockito.when(mock.files()).thenReturn(files);
+    @PullFiles("git/tracehub/codereview/action/github/small.json")
+    @ExtendWith(PullFilesExtension.class)
+    void skipsSmallPullRequests(final Pull mock) throws Exception {
         final LogCaptor capt = LogCaptor.forClass(SkipIfTooSmall.class);
         new SkipIfTooSmall(
             () -> 15,
@@ -103,17 +90,9 @@ final class SkipIfTooSmallTest {
     }
 
     @Test
-    @ExtendWith(MockitoExtension.class)
-    void doesNotSkipEnoughPullRequest(@Mock final Pull mock) throws Exception {
-        final List<JsonObject> files = new ListOf<>();
-        Json.createReader(
-            new InputStreamReader(
-                new ResourceOf(
-                    "git/tracehub/codereview/action/github/files.json"
-                ).stream()
-            )
-        ).readArray().forEach(value -> files.add(value.asJsonObject()));
-        Mockito.when(mock.files()).thenReturn(files);
+    @PullFiles("git/tracehub/codereview/action/github/files.json")
+    @ExtendWith(PullFilesExtension.class)
+    void doesNotSkipEnoughPullRequest(final Pull mock) throws Exception {
         final LogCaptor capt = LogCaptor.forClass(SkipIfTooSmall.class);
         new SkipIfTooSmall(
             () -> 15,

--- a/src/test/java/git/tracehub/codereview/action/extentions/PullFiles.java
+++ b/src/test/java/git/tracehub/codereview/action/extentions/PullFiles.java
@@ -21,37 +21,22 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
  */
-package git.tracehub.codereview.action.github;
+package git.tracehub.codereview.action.extentions;
 
-import com.jcabi.github.Pull;
-import git.tracehub.codereview.action.extentions.PullFiles;
-import git.tracehub.codereview.action.extentions.PullFilesExtension;
-import org.hamcrest.MatcherAssert;
-import org.hamcrest.core.IsEqual;
-import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
 
 /**
- * Test case for {@link ChangesCount}.
+ * Pull files.
  *
  * @since 0.0.0
  */
-final class ChangesCountTest {
+@Retention(RetentionPolicy.RUNTIME)
+public @interface PullFiles {
 
-    @Test
-    @PullFiles("git/tracehub/codereview/action/github/files.json")
-    @ExtendWith(PullFilesExtension.class)
-    void calculatesChanges(final Pull mock) throws Exception {
-        final int changes = new ChangesCount(mock).value();
-        final int expected = 31;
-        MatcherAssert.assertThat(
-            String.format(
-                "Changes count (%s) does not match with expected %s",
-                changes,
-                expected
-            ),
-            changes,
-            new IsEqual<>(expected)
-        );
-    }
+    /**
+     * File path.
+     * @return File path as a string
+     */
+    String value();
 }

--- a/src/test/java/git/tracehub/codereview/action/extentions/PullFilesExtension.java
+++ b/src/test/java/git/tracehub/codereview/action/extentions/PullFilesExtension.java
@@ -1,0 +1,70 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2024 Tracehub.git
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package git.tracehub.codereview.action.extentions;
+
+import com.jcabi.github.Pull;
+import java.io.InputStreamReader;
+import java.util.List;
+import java.util.Objects;
+import javax.json.Json;
+import javax.json.JsonObject;
+import lombok.SneakyThrows;
+import org.cactoos.io.ResourceOf;
+import org.cactoos.list.ListOf;
+import org.junit.jupiter.api.extension.ExtensionContext;
+import org.junit.jupiter.api.extension.ParameterContext;
+import org.junit.jupiter.api.extension.ParameterResolutionException;
+import org.junit.jupiter.api.extension.ParameterResolver;
+import org.mockito.Mockito;
+
+/**
+ * Pull Files JUnit extension for mocking Pull#files().
+ *
+ * @since 0.0.0
+ */
+public final class PullFilesExtension implements ParameterResolver {
+
+    @Override
+    public boolean supportsParameter(final ParameterContext pct, final ExtensionContext ect)
+        throws ParameterResolutionException {
+        return Objects.equals(pct.getParameter().getType(), Pull.class);
+    }
+
+    @SneakyThrows
+    @Override
+    public Object resolveParameter(final ParameterContext pct, final ExtensionContext ect)
+        throws ParameterResolutionException {
+        final Pull mock = Mockito.mock(Pull.class);
+        final List<JsonObject> files = new ListOf<>();
+        final PullFiles annotation = ect.getRequiredTestMethod()
+            .getAnnotation(PullFiles.class);
+        Json.createReader(
+            new InputStreamReader(
+                new ResourceOf(annotation.value()).stream()
+            )
+        ).readArray().forEach(value -> files.add(value.asJsonObject()));
+        Mockito.when(mock.files()).thenReturn(files);
+        return mock;
+    }
+}

--- a/src/test/java/git/tracehub/codereview/action/extentions/package-info.java
+++ b/src/test/java/git/tracehub/codereview/action/extentions/package-info.java
@@ -21,37 +21,10 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
  */
-package git.tracehub.codereview.action.github;
-
-import com.jcabi.github.Pull;
-import git.tracehub.codereview.action.extentions.PullFiles;
-import git.tracehub.codereview.action.extentions.PullFilesExtension;
-import org.hamcrest.MatcherAssert;
-import org.hamcrest.core.IsEqual;
-import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
 
 /**
- * Test case for {@link ChangesCount}.
+ * Test extensions.
  *
  * @since 0.0.0
  */
-final class ChangesCountTest {
-
-    @Test
-    @PullFiles("git/tracehub/codereview/action/github/files.json")
-    @ExtendWith(PullFilesExtension.class)
-    void calculatesChanges(final Pull mock) throws Exception {
-        final int changes = new ChangesCount(mock).value();
-        final int expected = 31;
-        MatcherAssert.assertThat(
-            String.format(
-                "Changes count (%s) does not match with expected %s",
-                changes,
-                expected
-            ),
-            changes,
-            new IsEqual<>(expected)
-        );
-    }
-}
+package git.tracehub.codereview.action.extentions;

--- a/src/test/resources/git/tracehub/codereview/action/github/compiled-array.json
+++ b/src/test/resources/git/tracehub/codereview/action/github/compiled-array.json
@@ -1,0 +1,30 @@
+[
+  {
+    "filename": "eo-maven-plugin/src/main/resources/org/eolang/maven/pre/to-java.xsl",
+    "additions": 0,
+    "deletions": 3,
+    "changes": 3,
+    "patch": "@@ -419,9 +419,6 @@ SOFTWARE.\n       <xsl:when test=\"$method='&amp;'\">\n         <xsl:text>σ</xsl:text>\n       </xsl:when>\n-      <xsl:when test=\"$method='&lt;'\">\n-        <xsl:text>ν</xsl:text>\n-      </xsl:when>\n       <xsl:otherwise>\n         <xsl:value-of select=\"eo:attr-name($method)\"/>\n       </xsl:otherwise>"
+  },
+  {
+    "filename": "eo-parser/src/test/resources/org/eolang/parser/packs/add-locators.yaml",
+    "additions": 5,
+    "deletions": 6,
+    "changes": 11,
+    "patch": "@@ -12,11 +12,10 @@ tests:\n   - //o[not(@base) and @name='e' and @loc='Φ.org.abc.tt.α2.e']\n   - //o[@base='.hello' and @loc='Φ.org.abc.tt.α2.φ']\n   - //o[@base='e' and @loc='Φ.org.abc.tt.α2.φ.ρ']\n-  - //o[@name='q' and @base='.<' and @loc='Φ.org.abc.q']\n-  - //o[@base='.p' and not(@name) and @loc='Φ.org.abc.q.ρ']\n-  - //o[@base='.^' and not(@name) and @loc='Φ.org.abc.q.ρ.ρ']\n-  - //o[@base='.&' and not(@name) and @loc='Φ.org.abc.q.ρ.ρ.ρ']\n-  - //o[@base='$' and not(@name) and @loc='Φ.org.abc.q.ρ.ρ.ρ.ρ']\n+  - //o[@name='q' and @base='.p' and @loc='Φ.org.abc.q']\n+  - //o[@base='.^' and not(@name) and @loc='Φ.org.abc.q.ρ']\n+  - //o[@base='.&' and not(@name) and @loc='Φ.org.abc.q.ρ.ρ']\n+  - //o[@base='$' and not(@name) and @loc='Φ.org.abc.q.ρ.ρ.ρ']\n eo: |\n   +alias org.abc.foo.b\n   +alias x\n@@ -38,4 +37,4 @@ eo: |\n     [e]\n       e.hello > @\n   \n-  $.&.^.p.< > q\n+  $.&.^.p > q"
+  },
+  {
+    "filename": "eo-parser/src/test/resources/org/eolang/parser/packs/full-syntax.yaml",
+    "additions": 6,
+    "deletions": 7,
+    "changes": 13,
+    "patch": "@@ -10,7 +10,6 @@ tests:\n   - //o[@as='1']\n   - //o[@as='0']\n   - //o[@base='&']\n-  - //o[@base='.<']\n   - //o[@base='.five']\n   - //objects[not(.//o[@name=''])]\n   - //o[@atom and @name='atom' and count(o)=2 and o[@name='a']]\n@@ -37,20 +36,20 @@ eo: |\n   [x] > first\n     x > @\n     second > hello\n-      $.plus.@ 5.< > i\n+      $.plus.@ 5 > i\n       third > x!\n         $\n-        <.\n+        z.\n           z\n         f\n           12:foo\n-          ((t' r 8.54 \"yes\".< \"\\t\").print 88 0x1f):hey\n-          TRUE.<:vtx\n+          ((t' r 8.54 \"yes\" \"\\t\").print 88 0x1f):hey\n+          TRUE:vtx\n           false:fle > a!\n             []\n               Q.x.f.d Q Q\n               QQ.y QQ\n-              &.@.< > t\n+              &.@ > t\n               ^.@.hey > you\n               Q\n               QQ\n@@ -91,7 +90,7 @@ eo: |\n   # This is the default 64+ symbols comment in front of abstract object.\n   [] > named\n     one.two.three.four.five\n-      t.<\n+      t.o\n     .two \"hello!\"\n     .three > a1\n     .four (a b c') > a2"
+  },
+  {
+    "filename": "eo-runtime/src/test/java/org/eolang/PhDefaultTest.java",
+    "additions": 2,
+    "deletions": 2,
+    "changes": 4,
+    "patch": "@@ -274,8 +274,8 @@ void hasContextedChildWithSetRhoWhenFormed() {\n     void makesObjectIdentity() {\n         final Phi phi = new PhDefaultTest.Int();\n         MatcherAssert.assertThat(\n-            new Dataized(phi.take(Attr.VERTEX)).take(Long.class),\n-            Matchers.greaterThan(0L)\n+            phi.hashCode(),\n+            Matchers.greaterThan(0)\n         );\n     }\n "
+  }
+]

--- a/src/test/resources/git/tracehub/codereview/action/github/compiled.json
+++ b/src/test/resources/git/tracehub/codereview/action/github/compiled.json
@@ -1,0 +1,9 @@
+[
+  {
+    "filename": "eo-maven-plugin/src/main/resources/org/eolang/maven/pre/to-java.xsl",
+    "additions": 0,
+    "deletions": 3,
+    "changes": 3,
+    "patch": "@@ -419,9 +419,6 @@ SOFTWARE.\n       <xsl:when test=\"$method='&amp;'\">\n         <xsl:text>σ</xsl:text>\n       </xsl:when>\n-      <xsl:when test=\"$method='&lt;'\">\n-        <xsl:text>ν</xsl:text>\n-      </xsl:when>\n       <xsl:otherwise>\n         <xsl:value-of select=\"eo:attr-name($method)\"/>\n       </xsl:otherwise>"
+  }
+]


### PR DESCRIPTION
closes #40
closes #41
History:
- **feat(#40, #41): PullChanges**


<!-- start pr-codex -->

---

## PR-Codex overview
This PR introduces changes related to mocking Pull#files() in unit tests and adds annotations for file paths in extensions.

### Detailed summary
- Added `@PullFiles` annotation for file paths in extensions.
- Created `PullFilesExtension` for mocking `Pull#files()` in unit tests.
- Updated unit tests to use the new annotations and extensions.

> The following files were skipped due to too many changes: `src/test/java/git/tracehub/codereview/action/extentions/PullFilesExtension.java`, `src/test/java/git/tracehub/codereview/action/github/PullChangesTest.java`, `src/test/resources/git/tracehub/codereview/action/github/compiled-array.json`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->