### PR TITLE
fix(#81): no default for deepinfra_model

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,8 +81,7 @@ These are the parameters you can use/override:
 * `github_token`: GitHub token in order to post comments in the pull request.
 * `openai_model`: Open AI ChatGPT model, the default one is `gpt-4`.
 * `deepinfra_token`: Deep Infra API key, you can obtain it [here](https://deepinfra.com/dash/api_keys).
-* `deepinfra_model`: Deep Infra API model, the default one is `Phind/Phind-CodeLlama-34B-v2`,
-  check out [all available models](https://deepinfra.com/models/text-generation).
+* `deepinfra_model`: Deep Infra API model, check out [all available models](https://deepinfra.com/models/text-generation).
 * `min_lines`: Minimal amount of lines in the pull request to get analyzed
 by this action, pull requests with fewer lines than provided `min_size`
 won't be processed.

--- a/action.yml
+++ b/action.yml
@@ -21,7 +21,6 @@ inputs:
   deepinfra_model:
     description: 'Deep Infra API model'
     required: false
-    default: 'Phind/Phind-CodeLlama-34B-v2'
   min_lines:
     description: 'Minimal amount of lines in the pull request to get analyzed by this action'
     required: false


### PR DESCRIPTION
ref #81

<!-- start pr-codex -->

---

## PR-Codex overview
This PR updates the `README.md` file by removing the default value for `deepinfra_model` and providing a link to all available models. 

### Detailed summary
- Removed default value for `deepinfra_model`
- Added link to all available models for Deep Infra API

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->