### PR TITLE
doc(#92): run if approved only

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ permissions:
   contents: read
 jobs:
   check:
+    if: ${{ github.event.review.state == 'approved' }}
     runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v4
@@ -62,6 +63,7 @@ permissions:
   contents: read
 jobs:
   check:
+    if: ${{ github.event.review.state == 'approved' }}
     runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
closes #92

<!-- start pr-codex -->

---

## PR-Codex overview
This PR adds a conditional check to run the job only when a GitHub review is approved.

### Detailed summary
- Added a conditional check to the job to run only when a GitHub review is approved.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->