### PR TITLE
85

### DIFF
--- a/src/main/java/git/tracehub/codereview/action/SkipIfMentioned.java
+++ b/src/main/java/git/tracehub/codereview/action/SkipIfMentioned.java
@@ -24,7 +24,9 @@
 /*
  * @todo #85:15min apply SkipIfMentioned too skip pull request.
  *  SkipIfMentioned should be applied on incoming pull request
- *  to check author on exclusion.
+ *  to check author on exclusion. Let's integrate this field with
+ *  action.yml inputs, so defined values will be injected into
+ *  mentions let's call this input skip_authors.
  */
 package git.tracehub.codereview.action;
 

--- a/src/main/java/git/tracehub/codereview/action/SkipIfMentioned.java
+++ b/src/main/java/git/tracehub/codereview/action/SkipIfMentioned.java
@@ -21,6 +21,11 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
  */
+/*
+ * @todo #85:15min apply SkipIfMentioned too skip pull request.
+ *  SkipIfMentioned should be applied on incoming pull request
+ *  to check author on exclusion.
+ */
 package git.tracehub.codereview.action;
 
 import com.jcabi.github.Pull;
@@ -53,7 +58,7 @@ public class SkipIfMentioned implements Proc<Pull> {
         if (this.mentions.contains(author)) {
             Logger.info(
                 this,
-                "Skipping pull request, author '%s' is excluded",
+                "Skipping pull request, since author '%s' is excluded",
                 author
             );
         } else {

--- a/src/main/java/git/tracehub/codereview/action/SkipIfMentioned.java
+++ b/src/main/java/git/tracehub/codereview/action/SkipIfMentioned.java
@@ -1,0 +1,63 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2024 Tracehub.git
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package git.tracehub.codereview.action;
+
+import com.jcabi.github.Pull;
+import com.jcabi.log.Logger;
+import java.util.Collection;
+import lombok.RequiredArgsConstructor;
+import org.cactoos.Proc;
+
+/**
+ * Skip pull request if author is excluded.
+ *
+ * @since 0.1.23
+ */
+@RequiredArgsConstructor
+public class SkipIfMentioned implements Proc<Pull> {
+
+    /**
+     * Authors to skip.
+     */
+    private final Collection<String> mentions;
+
+    /**
+     * Routine to run.
+     */
+    private final Proc<Pull> routine;
+
+    @Override
+    public final void exec(final Pull pull) throws Exception {
+        final String author = new Pull.Smart(pull).author().login();
+        if (this.mentions.contains(author)) {
+            Logger.info(
+                this,
+                "Skipping pull request, author '%s' is excluded",
+                author
+            );
+        } else {
+            this.routine.exec(pull);
+        }
+    }
+}

--- a/src/test/java/git/tracehub/codereview/action/SkipIfMentionedTest.java
+++ b/src/test/java/git/tracehub/codereview/action/SkipIfMentionedTest.java
@@ -25,9 +25,9 @@ package git.tracehub.codereview.action;
 
 import com.jcabi.github.Pull;
 import com.jcabi.log.Logger;
+import git.tracehub.codereview.action.extentions.PullRequestExtension;
 import java.util.Collections;
 import java.util.concurrent.atomic.AtomicBoolean;
-import git.tracehub.codereview.action.extentions.PullRequestExtension;
 import org.cactoos.list.ListOf;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.core.IsNot;

--- a/src/test/java/git/tracehub/codereview/action/SkipIfMentionedTest.java
+++ b/src/test/java/git/tracehub/codereview/action/SkipIfMentionedTest.java
@@ -1,0 +1,96 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2024 Tracehub.git
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package git.tracehub.codereview.action;
+
+import com.jcabi.github.Pull;
+import com.jcabi.github.mock.MkGithub;
+import com.jcabi.log.Logger;
+import java.io.IOException;
+import java.util.Collections;
+import java.util.concurrent.atomic.AtomicBoolean;
+import org.cactoos.list.ListOf;
+import org.hamcrest.MatcherAssert;
+import org.hamcrest.core.IsNot;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.llorllale.cactoos.matchers.IsTrue;
+
+/**
+ * Test suit for {@link SkipIfMentioned}.
+ *
+ * @since 0.1.23
+ */
+final class SkipIfMentionedTest {
+
+    /**
+     * Test pr.
+     */
+    private Pull pull;
+
+    @BeforeEach
+    void setUp() throws IOException {
+        this.pull = new Pull.Smart(
+            new MkGithub().randomRepo()
+                .pulls()
+                .create(
+                    "test-title",
+                    "test-head",
+                    "test-base"
+                )
+        );
+    }
+
+    @Test
+    void skipsWhenAuthorMentioned() throws Exception {
+        final AtomicBoolean skipped = new AtomicBoolean(true);
+        new SkipIfMentioned(
+            new ListOf<>("jeff", "not-jeff"),
+            ignored -> skipped.set(false)
+        ).exec(this.pull);
+        MatcherAssert.assertThat(
+            "Skipped flag should be 'true', but was '%s'".formatted(skipped.get()),
+            skipped.get(),
+            new IsTrue()
+        );
+    }
+
+    @Test
+    void processesAuthorMentioned() throws Exception {
+        final AtomicBoolean skipped = new AtomicBoolean(true);
+        new SkipIfMentioned(
+            Collections.emptyList(),
+            ignored -> {
+                Logger.info(this, "Processing pr...");
+                skipped.set(false);
+            }
+        ).exec(this.pull);
+        MatcherAssert.assertThat(
+            "Skipped flag should be 'false', but was '%s'".formatted(skipped.get()),
+            skipped.get(),
+            new IsNot<>(
+                new IsTrue()
+            )
+        );
+    }
+}

--- a/src/test/java/git/tracehub/codereview/action/SkipIfMentionedTest.java
+++ b/src/test/java/git/tracehub/codereview/action/SkipIfMentionedTest.java
@@ -21,6 +21,11 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
  */
+/*
+ * @todo #85:15min apply SkipIfMentioned too skip pull request.
+ *  SkipIfMentioned should be applied on incoming pull request
+ *  to check author on exclusion.
+ */
 package git.tracehub.codereview.action;
 
 import com.jcabi.github.Pull;

--- a/src/test/java/git/tracehub/codereview/action/SkipIfMentionedTest.java
+++ b/src/test/java/git/tracehub/codereview/action/SkipIfMentionedTest.java
@@ -21,24 +21,18 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
  */
-/*
- * @todo #85:15min apply SkipIfMentioned too skip pull request.
- *  SkipIfMentioned should be applied on incoming pull request
- *  to check author on exclusion.
- */
 package git.tracehub.codereview.action;
 
 import com.jcabi.github.Pull;
-import com.jcabi.github.mock.MkGithub;
 import com.jcabi.log.Logger;
-import java.io.IOException;
 import java.util.Collections;
 import java.util.concurrent.atomic.AtomicBoolean;
+import git.tracehub.codereview.action.extentions.PullRequestExtension;
 import org.cactoos.list.ListOf;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.core.IsNot;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.llorllale.cactoos.matchers.IsTrue;
 
 /**
@@ -48,31 +42,14 @@ import org.llorllale.cactoos.matchers.IsTrue;
  */
 final class SkipIfMentionedTest {
 
-    /**
-     * Test pr.
-     */
-    private Pull pull;
-
-    @BeforeEach
-    void setUp() throws IOException {
-        this.pull = new Pull.Smart(
-            new MkGithub().randomRepo()
-                .pulls()
-                .create(
-                    "test-title",
-                    "test-head",
-                    "test-base"
-                )
-        );
-    }
-
     @Test
-    void skipsWhenAuthorMentioned() throws Exception {
+    @ExtendWith(PullRequestExtension.class)
+    void skipsWhenAuthorMentioned(final Pull pull) throws Exception {
         final AtomicBoolean skipped = new AtomicBoolean(true);
         new SkipIfMentioned(
             new ListOf<>("jeff", "not-jeff"),
             ignored -> skipped.set(false)
-        ).exec(this.pull);
+        ).exec(pull);
         MatcherAssert.assertThat(
             "Skipped flag should be 'true', but was '%s'".formatted(skipped.get()),
             skipped.get(),
@@ -81,7 +58,8 @@ final class SkipIfMentionedTest {
     }
 
     @Test
-    void processesAuthorMentioned() throws Exception {
+    @ExtendWith(PullRequestExtension.class)
+    void processesAuthorMentioned(final Pull pull) throws Exception {
         final AtomicBoolean skipped = new AtomicBoolean(true);
         new SkipIfMentioned(
             Collections.emptyList(),
@@ -89,7 +67,7 @@ final class SkipIfMentionedTest {
                 Logger.info(this, "Processing pr...");
                 skipped.set(false);
             }
-        ).exec(this.pull);
+        ).exec(pull);
         MatcherAssert.assertThat(
             "Skipped flag should be 'false', but was '%s'".formatted(skipped.get()),
             skipped.get(),

--- a/src/test/java/git/tracehub/codereview/action/extentions/PullRequestExtension.java
+++ b/src/test/java/git/tracehub/codereview/action/extentions/PullRequestExtension.java
@@ -1,0 +1,68 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2024 Tracehub.git
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package git.tracehub.codereview.action.extentions;
+
+import com.jcabi.github.Pull;
+import com.jcabi.github.mock.MkGithub;
+import java.io.IOException;
+import java.util.Objects;
+import org.junit.jupiter.api.extension.ExtensionContext;
+import org.junit.jupiter.api.extension.ParameterContext;
+import org.junit.jupiter.api.extension.ParameterResolver;
+
+/**
+ * Just dummy pull request.
+ *
+ * @since 0.1.23
+ */
+public final class PullRequestExtension implements ParameterResolver {
+
+    @Override
+    public boolean supportsParameter(
+        final ParameterContext pctx,
+        final ExtensionContext ectx
+    ) {
+        return Objects.equals(pctx.getParameter().getType(), Pull.class);
+    }
+
+    @Override
+    public Object resolveParameter(
+        final ParameterContext pctx,
+        final ExtensionContext ectx
+    ) {
+        try {
+            return new Pull.Smart(
+                new MkGithub().randomRepo()
+                    .pulls()
+                    .create(
+                        "test-title",
+                        "test-head",
+                        "test-base"
+                    )
+            );
+        } catch (final IOException exc) {
+            throw new IllegalStateException(exc);
+        }
+    }
+}


### PR DESCRIPTION
closes #85

<!-- start pr-codex -->

---

## PR-Codex overview
This PR adds license headers to files, introduces a `PullRequestExtension` for testing, and implements `SkipIfMentioned` to skip PRs based on authors.

### Detailed summary
- Added MIT license headers to files
- Created `PullRequestExtension` for testing
- Implemented `SkipIfMentioned` to skip PRs based on authors

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->