### PR TITLE
feat(#112): skip_authors

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,6 +87,8 @@ These are the parameters you can use/override:
 * `min_lines`: Minimal amount of lines in the pull request to get analyzed
 by this action, pull requests with fewer lines than provided `min_size`
 won't be processed.
+* `skip_authors`: GitHub logins of authors, whose pull requests you want to
+skip from analyzing. By default, `renovatebot` and `dependabot` are ignored.
 
 ### Analysis Method
 

--- a/action.yml
+++ b/action.yml
@@ -24,6 +24,10 @@ inputs:
   min_lines:
     description: 'Minimal amount of lines in the pull request to get analyzed by this action'
     required: false
+  skip_authors:
+    description: 'GitHub logins of authors, whose pull requests you want to skip from analyzing'
+    default: '["renovate", "dependabot"]'
+    required: false
 runs:
   using: 'docker'
   image: 'Dockerfile'

--- a/src/main/java/git/tracehub/codereview/action/SkipAuthors.java
+++ b/src/main/java/git/tracehub/codereview/action/SkipAuthors.java
@@ -61,7 +61,7 @@ public final class SkipAuthors implements Scalar<Collection<String>> {
      *
      * @param skip Authors which will be skipped.
      */
-    SkipAuthors(final String... skip) {
+    public SkipAuthors(final String... skip) {
         this(new ListOf<>(skip));
     }
 

--- a/src/main/java/git/tracehub/codereview/action/SkipIfMentioned.java
+++ b/src/main/java/git/tracehub/codereview/action/SkipIfMentioned.java
@@ -59,7 +59,8 @@ public class SkipIfMentioned implements BiProc<Pull, String> {
         if (this.mentions.value().contains(author)) {
             Logger.info(
                 this,
-                "Skipping pull request, since author '%s' is excluded",
+                "Skipping pull request #%d, since author @%s is excluded",
+                pull.number(),
                 author
             );
         } else {

--- a/src/test/java/it/SkipIfMentionedITCase.java
+++ b/src/test/java/it/SkipIfMentionedITCase.java
@@ -21,80 +21,66 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
  */
-package git.tracehub.codereview.action;
+package it;
 
+import com.jcabi.github.Coordinates;
+import com.jcabi.github.Github;
 import com.jcabi.github.Pull;
-import com.jcabi.log.Logger;
-import git.tracehub.codereview.action.extentions.PullRequestExtension;
-import java.util.Collections;
+import com.yegor256.WeAreOnline;
+import git.tracehub.codereview.action.AnalysisRoutine;
+import git.tracehub.codereview.action.MinLines;
+import git.tracehub.codereview.action.SkipAuthors;
+import git.tracehub.codereview.action.SkipIfMentioned;
+import git.tracehub.codereview.action.SkipIfTooSmall;
+import git.tracehub.codereview.action.github.GhIdentity;
+import io.github.h1alexbel.ghquota.Quota;
 import java.util.List;
-import java.util.concurrent.atomic.AtomicBoolean;
 import nl.altindag.log.LogCaptor;
 import org.cactoos.list.ListOf;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.core.IsEqual;
-import org.hamcrest.core.IsNot;
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
-import org.llorllale.cactoos.matchers.IsTrue;
 
 /**
- * Test suit for {@link SkipIfMentioned}.
+ * Integration test case for {@link SkipIfMentioned}.
  *
- * @since 0.1.23
+ * @since 0.2.0
  */
-final class SkipIfMentionedTest {
+final class SkipIfMentionedITCase {
 
     @Test
-    @ExtendWith(PullRequestExtension.class)
-    void skipsWhenAuthorMentioned(final Pull pull) throws Exception {
-        final AtomicBoolean skipped = new AtomicBoolean(true);
-        new SkipIfMentioned(
-            new SkipAuthors("jeff", "not-jeff"),
-            (a, b) -> skipped.set(false)
-        ).exec(pull, "meh");
-        MatcherAssert.assertThat(
-            "Skipped flag should be 'true', but was '%s'".formatted(skipped.get()),
-            skipped.get(),
-            new IsTrue()
-        );
-    }
-
-    @Test
-    @ExtendWith(PullRequestExtension.class)
-    void processesAuthorMentioned(final Pull pull) throws Exception {
-        final AtomicBoolean skipped = new AtomicBoolean(true);
-        new SkipIfMentioned(
-            new SkipAuthors(Collections.emptyList()),
-            (a, b) -> {
-                Logger.info(this, "Processing pr...");
-                skipped.set(false);
-            }
-        ).exec(pull, "meh");
-        MatcherAssert.assertThat(
-            "Skipped flag should be 'false', but was '%s'".formatted(skipped.get()),
-            skipped.get(),
-            new IsNot<>(
-                new IsTrue()
-            )
-        );
-    }
-
-    @Test
-    @ExtendWith(PullRequestExtension.class)
-    void addsLogsWhenSkips(final Pull pull) throws Exception {
+    @Tag("simulation")
+    @ExtendWith({WeAreOnline.class, Quota.class})
+    void skipsAuthorPull() throws Exception {
         final LogCaptor capt = LogCaptor.forClass(SkipIfMentioned.class);
-        final String skip = "jeff";
+        final Github github = new GhIdentity().value();
+        final Pull pull = github.repos()
+            .get(new Coordinates.Simple("tracehubpm/test"))
+            .pulls()
+            .get(5);
+        final String token = System.getProperty("INPUT_GITHUB_TOKEN");
+        final String skip = "h1alexbel";
         new SkipIfMentioned(
             new SkipAuthors(skip),
-            (incoming, param) -> Logger.info(SkipIfMentioned.class, "Boom!")
-        ).exec(pull, "");
+            new SkipIfTooSmall(
+                new MinLines(),
+                new AnalysisRoutine(
+                    token,
+                    github.users().self().login(),
+                    System.getenv().get("INPUT_DEEPINFRA_TOKEN")
+                )
+            )
+        ).exec(
+            pull,
+            System.getenv().get("INPUT_DEEPINFRA_MODEL")
+        );
         final List<String> logs = capt.getInfoLogs();
         final List<String> expected = new ListOf<>(
             String.format(
                 "Skipping pull request #%d, since author @%s is excluded",
-                pull.number(),
-                skip
+                pull.number(), skip
             )
         );
         MatcherAssert.assertThat(


### PR DESCRIPTION
closes #112

<!-- start pr-codex -->

---

## PR-Codex overview
This PR updates the SkipAuthors constructor to be public, adds the ability to skip authors in the action configuration, and includes new tests for SkipIfMentioned.

### Detailed summary
- Updated `SkipAuthors` constructor to be public
- Added `skip_authors` parameter in action configuration
- Added tests for `SkipIfMentioned` in `SkipIfMentionedTest.java` and `SkipIfMentionedITCase.java`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->