### PR TITLE
not openai_token req

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -32,7 +32,7 @@ inputs:
     required: true
   openai_token:
     description: 'Open AI API key'
-    required: true
+    required: false
   openai_model:
     description: 'Open AI API model'
     required: false


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR updates the `openai_token` field in the action configuration file to be optional instead of required.

### Detailed summary
- Updated `openai_token` field to be optional
- No longer required for the action to run

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->