### PR TITLE
fix(#131): no chat in the url

### DIFF
--- a/src/main/java/git/tracehub/codereview/action/openai/OpenRequest.java
+++ b/src/main/java/git/tracehub/codereview/action/openai/OpenRequest.java
@@ -50,10 +50,10 @@ public final class OpenRequest implements Scalar<Request> {
     @Override
     public Request value() throws Exception {
         return new JdkRequest(
-            "https://api.openai.com/v1/chat/completions"
+            "https://api.openai.com/v1/completions"
         ).method("POST")
-            .header("Authorization", String.format("Bearer %s", this.token))
             .header("Content-Type", "application/json")
+            .header("Authorization", String.format("Bearer %s", this.token))
             .body()
             .set(this.body.value())
             .back();


### PR DESCRIPTION
ref #131

<!-- start pr-codex -->

---

## PR-Codex overview
The focus of this PR is to update the API endpoint in `OpenRequest.java` from `/chat/completions` to `/completions`.

### Detailed summary
- Updated API endpoint from `/chat/completions` to `/completions` in `OpenRequest.java`
- Adjusted header and body handling in the request function

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->